### PR TITLE
Adding RÈGLEMENT 604/2013 to international conv

### DIFF
--- a/opj.pred.oqtf.R
+++ b/opj.pred.oqtf.R
@@ -117,6 +117,7 @@ dt.patterns <- data.table(
   supralegem_2000_ = stri_count(dt.decision$decision, fixed = "12 avril 2000"),
   supralegem_2006_ = stri_count(dt.decision$decision, fixed = "24 juillet 2006"),
   supralegem_1968_ = stri_count(dt.decision$decision, fixed = "27 décembre 1968"),
+  supralegem_dublin_ = stri_count(dt.decision$decision, fixed = "26 juin 2013"),  # Règlement (UE) n° 604/2013 du Parlement européen et du Conseil du 26 juin 2013
   
   # Réglements (fixed pour la vitesse)
   supralegem_l_761_1_ = stri_count(dt.decision$demande.enrichi, fixed = "l 761 1"), # ne doit pas voir l ensemble de la décision


### PR DESCRIPTION
Adding the _RÈGLEMENT  (UE)  No 604/2013  DU  PARLEMENT  EUROPÉEN  ET  DU  CONSEIL du  26  juin  2013 établissant  les  critères  et  mécanismes  de  détermination  de  l’État  membre  responsable  de  l’examen d’une   demande   de   protection   internationale   introduite   dans   l’un   des   États   membres   par   un ressortissant  de  pays  tiers  ou  un  apatride  (refonte)_ (see: http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=OJ:L:2013:180:0031:0059:FR:PDF )

Often cited in OQTF decisions (i.e. https://www.legifrance.gouv.fr/affichJuriAdmin.do?idTexte=CETATEXT000032496421 )